### PR TITLE
Update business_time gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'http://rubygems.org'
 # Example:
 #   gem 'activesupport', '>= 2.3.5'
 gem 'rest-client', '~> 2.0'
-gem 'business_time', '~> 0.7.6'
+gem 'business_time', '~> 0.9.3'
 
 # Add dependencies to develop your gem here.
 # Include everything needed to run rake, tests, features, etc.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,8 +8,8 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.4.0)
     builder (3.2.2)
-    business_time (0.7.6)
-      activesupport (>= 3.1.0)
+    business_time (0.9.3)
+      activesupport (>= 3.2.0)
       tzinfo
     concurrent-ruby (1.0.2)
     descendants_tracker (0.0.4)
@@ -98,7 +98,7 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 1.0)
-  business_time (~> 0.7.6)
+  business_time (~> 0.9.3)
   jeweler (~> 2.1)
   mocha
   rdoc (~> 3.12)
@@ -108,4 +108,4 @@ DEPENDENCIES
   test-unit
 
 BUNDLED WITH
-   1.13.6
+   1.16.0

--- a/pivotal-tracker-api.gemspec
+++ b/pivotal-tracker-api.gemspec
@@ -76,20 +76,20 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<rest-client>, ["~> 1.7"])
-      s.add_runtime_dependency(%q<business_time>, ["~> 0.7.6"])
+      s.add_runtime_dependency(%q<business_time>, ["~> 0.9.3"])
       s.add_development_dependency(%q<rdoc>, ["~> 3.12"])
       s.add_development_dependency(%q<bundler>, ["~> 1.0"])
       s.add_development_dependency(%q<jeweler>, ["~> 2.1"])
     else
       s.add_dependency(%q<rest-client>, ["~> 1.7"])
-      s.add_dependency(%q<business_time>, ["~> 0.7.6"])
+      s.add_dependency(%q<business_time>, ["~> 0.9.3"])
       s.add_dependency(%q<rdoc>, ["~> 3.12"])
       s.add_dependency(%q<bundler>, ["~> 1.0"])
       s.add_dependency(%q<jeweler>, ["~> 2.1"])
     end
   else
     s.add_dependency(%q<rest-client>, ["~> 1.7"])
-    s.add_dependency(%q<business_time>, ["~> 0.7.6"])
+    s.add_dependency(%q<business_time>, ["~> 0.9.3"])
     s.add_dependency(%q<rdoc>, ["~> 3.12"])
     s.add_dependency(%q<bundler>, ["~> 1.0"])
     s.add_dependency(%q<jeweler>, ["~> 2.1"])


### PR DESCRIPTION
Updated business_time to fix the deprecation warning for when the gem is
used in Ruby versions > 2.4.